### PR TITLE
restore hc/wasm build by downgrading quickcheck in rep_lang

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4839,7 +4839,6 @@ name = "social_sensemaker"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "combine",
  "common",
  "futures",
  "hdk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,6 +601,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3e1238132dc01f081e1cbb9dace14e5ef4c3a51ee244bd982275fb514605db"
+dependencies = [
+ "error-code",
+ "str-buf",
+ "winapi",
+]
+
+[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "dirs-next"
-version = "1.0.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf36e65a80337bea855cd4ef9b8401ffce06a7baedf2e85ec467b1ac3f6e82b6"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if 1.0.0",
  "dirs-sys-next",
@@ -1124,6 +1135,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "enumset"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1175,6 +1192,16 @@ dependencies = [
  "rustversion",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "error-code"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
+dependencies = [
+ "libc",
+ "str-buf",
 ]
 
 [[package]]
@@ -3106,15 +3133,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.18.0"
+name = "nibble_vec"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec 1.8.0",
+]
+
+[[package]]
+name = "nix"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -3722,12 +3759,14 @@ dependencies = [
 
 [[package]]
 name = "pretty"
-version = "0.10.0"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad9940b913ee56ddd94aec2d3cd179dd47068236f42a1a6415ccf9d880ce2a61"
+checksum = "83f3aa1e3ca87d3b124db7461265ac176b40c277f37e503eaa29c9c75c037846"
 dependencies = [
  "arrayvec 0.5.2",
+ "log",
  "typed-arena",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -3923,6 +3962,16 @@ checksum = "75681c1503fca52049c7236548026c156b51a452440bfa4be2074dc06fe5ce6f"
 dependencies = [
  "r2d2",
  "rusqlite",
+]
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
 ]
 
 [[package]]
@@ -4259,19 +4308,18 @@ dependencies = [
 [[package]]
 name = "rep_lang_concrete_syntax"
 version = "0.1.0"
-source = "git+https://github.com/neighbour-hoods/rep_lang.git?rev=c321016c1d3d9fe548a1df1c47e1748d5bff6f87#c321016c1d3d9fe548a1df1c47e1748d5bff6f87"
+source = "git+https://github.com/neighbour-hoods/rep_lang.git?rev=364213a6b1bca2f3ebdedb9a043c0b864e4d6a49#364213a6b1bca2f3ebdedb9a043c0b864e4d6a49"
 dependencies = [
  "combine",
  "pretty",
  "quickcheck",
- "rand 0.7.3",
  "rep_lang_core",
 ]
 
 [[package]]
 name = "rep_lang_core"
 version = "0.1.0"
-source = "git+https://github.com/neighbour-hoods/rep_lang.git?rev=c321016c1d3d9fe548a1df1c47e1748d5bff6f87#c321016c1d3d9fe548a1df1c47e1748d5bff6f87"
+source = "git+https://github.com/neighbour-hoods/rep_lang.git?rev=364213a6b1bca2f3ebdedb9a043c0b864e4d6a49#364213a6b1bca2f3ebdedb9a043c0b864e4d6a49"
 dependencies = [
  "hdk",
  "holochain_serialized_bytes_derive",
@@ -4283,9 +4331,8 @@ dependencies = [
 [[package]]
 name = "rep_lang_runtime"
 version = "0.1.0"
-source = "git+https://github.com/neighbour-hoods/rep_lang.git?rev=c321016c1d3d9fe548a1df1c47e1748d5bff6f87#c321016c1d3d9fe548a1df1c47e1748d5bff6f87"
+source = "git+https://github.com/neighbour-hoods/rep_lang.git?rev=364213a6b1bca2f3ebdedb9a043c0b864e4d6a49#364213a6b1bca2f3ebdedb9a043c0b864e4d6a49"
 dependencies = [
- "byteorder",
  "combine",
  "hdk",
  "holochain_serialized_bytes_derive",
@@ -4509,16 +4556,18 @@ checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
 name = "rustyline"
-version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0d5e7b0219a3eadd5439498525d4765c59b7c993ef0c12244865cd2d988413"
+version = "9.1.2"
+source = "git+https://github.com/neighbour-hoods/rustyline?branch=acs/wasm-web-support#1ff29c8f292e72605022bff66b2e19cf4644c81a"
 dependencies = [
- "cfg-if 0.1.10",
+ "bitflags",
+ "cfg-if 1.0.0",
+ "clipboard-win",
  "dirs-next",
  "libc",
  "log",
  "memchr",
  "nix",
+ "radix_trie",
  "scopeguard",
  "unicode-segmentation",
  "unicode-width",
@@ -4872,6 +4921,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "str-buf"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
 name = "str_stack"

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -9,10 +9,10 @@ license-file = "../../LICENSE"
 base64 = "0.13.0"
 combine = "4.5.2"
 hdk = "0.0.136"
-pretty = "0.10.0"
+pretty = "0.11.3"
 serde = "1"
 
-rep_lang_concrete_syntax = { git = "https://github.com/neighbour-hoods/rep_lang.git", rev = "c321016c1d3d9fe548a1df1c47e1748d5bff6f87" }
-rep_lang_core = { git = "https://github.com/neighbour-hoods/rep_lang.git", rev = "c321016c1d3d9fe548a1df1c47e1748d5bff6f87", features = ["hc"] }
-rep_lang_runtime = { git = "https://github.com/neighbour-hoods/rep_lang.git", rev = "c321016c1d3d9fe548a1df1c47e1748d5bff6f87", features = ["hc"] }
+rep_lang_concrete_syntax = { git = "https://github.com/neighbour-hoods/rep_lang.git", rev = "364213a6b1bca2f3ebdedb9a043c0b864e4d6a49" }
+rep_lang_core = { git = "https://github.com/neighbour-hoods/rep_lang.git", rev = "364213a6b1bca2f3ebdedb9a043c0b864e4d6a49", features = ["hc"] }
+rep_lang_runtime = { git = "https://github.com/neighbour-hoods/rep_lang.git", rev = "364213a6b1bca2f3ebdedb9a043c0b864e4d6a49", features = ["hc"] }
 social_sensemaker_macros = { path = "../social_sensemaker_macros" }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -7,7 +7,7 @@ license-file = "../../LICENSE"
 
 [dependencies]
 base64 = "0.13.0"
-combine = "4.5.2"
+combine = "4.6.4"
 hdk = "0.0.136"
 pretty = "0.11.3"
 serde = "1"

--- a/crates/social_sensemaker/Cargo.toml
+++ b/crates/social_sensemaker/Cargo.toml
@@ -8,7 +8,6 @@ license-file = "../../LICENSE"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-combine = "4.5.2"
 hdk = "0.0.136"
 serde = "1"
 

--- a/crates/social_sensemaker/Cargo.toml
+++ b/crates/social_sensemaker/Cargo.toml
@@ -13,9 +13,9 @@ hdk = "0.0.136"
 serde = "1"
 
 common = { path = "../common" }
-rep_lang_concrete_syntax = { git = "https://github.com/neighbour-hoods/rep_lang.git", rev = "c321016c1d3d9fe548a1df1c47e1748d5bff6f87" }
-rep_lang_core = { git = "https://github.com/neighbour-hoods/rep_lang.git", rev = "c321016c1d3d9fe548a1df1c47e1748d5bff6f87", features = ["hc"] }
-rep_lang_runtime = { git = "https://github.com/neighbour-hoods/rep_lang.git", rev = "c321016c1d3d9fe548a1df1c47e1748d5bff6f87", features = ["hc"] }
+rep_lang_concrete_syntax = { git = "https://github.com/neighbour-hoods/rep_lang.git", rev = "364213a6b1bca2f3ebdedb9a043c0b864e4d6a49" }
+rep_lang_core = { git = "https://github.com/neighbour-hoods/rep_lang.git", rev = "364213a6b1bca2f3ebdedb9a043c0b864e4d6a49", features = ["hc"] }
+rep_lang_runtime = { git = "https://github.com/neighbour-hoods/rep_lang.git", rev = "364213a6b1bca2f3ebdedb9a043c0b864e4d6a49", features = ["hc"] }
 
 [dev-dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
our wasm build was borked due to changes in #37. those changes were reverted in #43.

here we can bring some of those changes back, b/c I identified that the problem seems to stem from `getrandom`, which is a dep of `quickcheck`, which I decided to move back to the `0.9.2` release.

more details here: https://github.com/neighbour-hoods/rep_lang/pull/79